### PR TITLE
update hub to v1.3.0

### DIFF
--- a/docker/farcaster-hubble/Dockerfile
+++ b/docker/farcaster-hubble/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:alpine
 
 # https://github.com/farcasterxyz/hubble/tags
-ARG HUBBLE_VERSION="@farcaster/hubble@1.2.0"
+ARG HUBBLE_VERSION="@farcaster/hubble@1.3.0"
 
 # Install required dependencies
 RUN apk update && \

--- a/terraform/gke_docker_image.tf
+++ b/terraform/gke_docker_image.tf
@@ -1,4 +1,4 @@
 locals {
-  image_tag = "sha256:0cf917d9980afb899e84c843551ba0cef700757cdf273c193db4302347121cd3"
+  image_tag = "sha256:893c8d4553350d5482a126e012a05f12ad9fa7f4be364fe8f64679ba0acabd19"
   image     = "${var.region}-docker.pkg.dev/${var.project-id}/${google_artifact_registry_repository.artifact-registry.repository_id}/farcaster-hubble@${local.image_tag}"
 }


### PR DESCRIPTION
I've followed the steps in the README [here](https://github.com/standard-crypto/farcaster-hub-gcp#update-instructions)