### PR TITLE
changes to dockerfile to build 1.4.5

### DIFF
--- a/docker/farcaster-hubble/Dockerfile
+++ b/docker/farcaster-hubble/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.2-alpine AS build
+FROM node:20.2-alpine
 
 # https://github.com/farcasterxyz/hubble/tags
 ARG HUBBLE_VERSION="@farcaster/hubble@1.4.5"

--- a/docker/farcaster-hubble/Dockerfile
+++ b/docker/farcaster-hubble/Dockerfile
@@ -1,14 +1,21 @@
-FROM python:alpine
+FROM node:20.2-alpine AS build
 
 # https://github.com/farcasterxyz/hubble/tags
-ARG HUBBLE_VERSION="@farcaster/hubble@1.4.3"
+ARG HUBBLE_VERSION="@farcaster/hubble@1.4.5"
 
 # Install required dependencies
-RUN apk update && \
-    apk add --no-cache git && \
-    apk add --no-cache yarn && \
-    apk add --no-cache libc6-compat && \
-    apk add --no-cache flatbuffers
+RUN apk add --no-cache libc6-compat python3 make g++ linux-headers curl git
+
+USER node
+RUN mkdir /home/node/app
+WORKDIR /home/node/app
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.70.0
+ENV PATH="/home/node/.cargo/bin:${PATH}"
+
+# Rust flags to allow building with musl, which is needed for alpine
+ENV RUSTFLAGS="-C target-feature=-crt-static"
 
 # Clone the Hubble repository and install dependencies
 RUN git clone https://github.com/farcasterxyz/hubble.git && \
@@ -17,11 +24,11 @@ RUN git clone https://github.com/farcasterxyz/hubble.git && \
     yarn install
 
 # Build the Hubble app
-WORKDIR /hubble
+WORKDIR /home/node/app/hubble/
 RUN yarn run build
 
 # Change to the Hubble app directory and create the network identity
-WORKDIR /hubble/apps/hubble
+WORKDIR /home/node/app/hubble/apps/hubble
 
 CMD yarn start \
     --eth-rpc-url="$ETH_GOERLI_RPC_URL" \

--- a/terraform/gke_docker_image.tf
+++ b/terraform/gke_docker_image.tf
@@ -1,5 +1,5 @@
 locals {
-  image_tag            = "sha256:70afa98774ef4ae34f2e6e656a10cdb1c79c8bf64098a01ccf4ae1f84f83d615"
+  image_tag            = "sha256:5ee551a1ea487ce96c5e5e4b0c42b2696e053e27100b042bbbf5b8429f31ee92"
   image                = "${var.region}-docker.pkg.dev/${var.project-id}/${google_artifact_registry_repository.artifact-registry.repository_id}/farcaster-hubble@${local.image_tag}"
   prometheus-image_tag = "sha256:99864de019d3cd63c01b4f0b1676e1d93dee5a0c0425298aeec59e9937014210"
   prometheus-image     = "${var.region}-docker.pkg.dev/${var.project-id}/${google_artifact_registry_repository.artifact-registry.repository_id}/prometheus@${local.prometheus-image_tag}"


### PR DESCRIPTION
This PR updates the hubble dockerfile to install Rust , which is required starting with v1.4.5