### PR TITLE
add grpc service to get sync state metrics

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -15,3 +15,9 @@ target "prometheus" {
     platforms = ["linux/amd64"]
     context = "./docker/prometheus"
 }
+
+target "grpc-exporter" {
+    tags = ["us-west1-docker.pkg.dev/sc-farcaster/docker/grpc-exporter"]
+    platforms = ["linux/amd64"]
+    context = "./docker/grpc-exporter"
+}

--- a/docker/grpc-exporter/Dockerfile
+++ b/docker/grpc-exporter/Dockerfile
@@ -1,0 +1,20 @@
+FROM --platform=linux/amd64 python
+
+RUN apt-get update && \
+    apt-get install -y jq && \
+    cd /tmp && \
+    wget https://github.com/fullstorydev/grpcurl/releases/download/v1.8.5/grpcurl_1.8.5_linux_x86_64.tar.gz && \
+    tar -xvf grpcurl_1.8.5_linux_x86_64.tar.gz && \
+    mv grpcurl /usr/bin
+
+WORKDIR /app
+
+COPY app/requirements.txt requirements.txt
+
+RUN pip install -r requirements.txt
+
+COPY app /app
+
+EXPOSE 9090
+
+CMD [ "python", "-u", "server.py" ]

--- a/docker/grpc-exporter/app/requirements.txt
+++ b/docker/grpc-exporter/app/requirements.txt
@@ -1,0 +1,1 @@
+prometheus_client

--- a/docker/grpc-exporter/app/rpc.proto
+++ b/docker/grpc-exporter/app/rpc.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+// models taken from https://github.com/farcasterxyz/hub-monorepo/blob/main/protobufs/schemas/request_response.proto
 
 message HubInfoRequest {
   bool db_stats = 1;

--- a/docker/grpc-exporter/app/rpc.proto
+++ b/docker/grpc-exporter/app/rpc.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+
+message HubInfoRequest {
+  bool db_stats = 1;
+}
+
+// Response Types for the Sync RPC Methods
+message HubInfoResponse {
+  string version = 1;
+  bool is_syncing = 2;
+  string nickname = 3;
+  string root_hash = 4;
+  DbStats db_stats = 5;
+}
+
+message DbStats {
+  uint64 num_messages = 1;
+  uint64 num_fid_events = 2;
+  uint64 num_fname_events = 3;
+}
+
+message SyncStatusRequest {
+  optional string peerId = 1;
+}
+
+message SyncStatusResponse {
+  bool is_syncing = 1;
+  repeated SyncStatus sync_status = 2;
+  bool engine_started = 3;
+}
+
+message SyncStatus {
+  string peerId = 1;
+  string inSync = 2;
+  bool shouldSync = 3;
+  string divergencePrefix = 4;
+  int32 divergenceSecondsAgo = 5;
+  uint64 theirMessages = 6;
+  uint64 ourMessages = 7;
+  int64 lastBadSync = 8;
+}
+
+
+service HubService {
+  // Sync Methods
+  rpc GetInfo(HubInfoRequest) returns (HubInfoResponse);
+  rpc GetSyncStatus(SyncStatusRequest) returns (SyncStatusResponse);
+}

--- a/docker/grpc-exporter/app/scripts/sync_state.sh
+++ b/docker/grpc-exporter/app/scripts/sync_state.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -u
+set -e
+
+: "$FC_HOSTNAME"
+
+grpcurl \
+    -plaintext \
+    -proto rpc.proto \
+    $FC_HOSTNAME:2283 \
+    HubService/GetSyncStatus

--- a/docker/grpc-exporter/app/server.py
+++ b/docker/grpc-exporter/app/server.py
@@ -1,0 +1,69 @@
+import os
+import time
+import subprocess
+import json
+from prometheus_client import start_http_server, Gauge
+
+
+class AppMetrics:
+    """
+    Representation of Prometheus metrics and loop to fetch and transform
+    application metrics into Prometheus metrics.
+    """
+
+    def __init__(self, polling_interval_seconds=60):
+        self.polling_interval_seconds = polling_interval_seconds
+
+        # Prometheus metrics to collect
+        self.ourMessages = Gauge("our_message_height", "Our Messages", ['peerId'])
+        self.theirMessages = Gauge("their_message_height", "Their Messages", ['peerId'])
+        self.divergenceSecondsAgo = Gauge("divergence_seconds_ago", "Divergence Seconds Ago", ['peerId'])
+        self.lastBadSync = Gauge("last_bad_sync", "Last Bad Sync", ['peerId'])
+
+
+    def run_metrics_loop(self):
+        """Metrics fetching loop"""
+
+        while True:
+            self.fetch_all()
+            time.sleep(self.polling_interval_seconds)
+
+    def fetch_all(self):
+        """
+        Get metrics from application and refresh Prometheus metrics with
+        new values.
+        """
+        self.fetch_sync_state()
+
+    def fetch_sync_state(self):
+        print("Fetching sync state...")
+
+        # Fetch raw status data from the application
+        result = subprocess.run(["./scripts/sync_state.sh"], stdout=subprocess.PIPE)
+        result.check_returncode()
+        resp = json.loads(result.stdout)
+        for state in resp["syncStatus"]:
+            self.ourMessages.labels(peerId=state["peerId"]).set(int(state["ourMessages"]))
+            self.theirMessages.labels(peerId=state["peerId"]).set(int(state["theirMessages"]))
+            self.divergenceSecondsAgo.labels(peerId=state["peerId"]).set(int(state["divergenceSecondsAgo"]))
+            self.lastBadSync.labels(peerId=state["peerId"]).set(int(state["lastBadSync"]))
+
+        print("Exported sync state...")
+
+
+
+def main():
+    """Main entry point"""
+
+    polling_interval_seconds = int(os.getenv("POLLING_INTERVAL_SECONDS", "60"))
+    exporter_port = int(os.getenv("EXPORTER_PORT", "9090"))
+
+    app_metrics = AppMetrics(
+        polling_interval_seconds=polling_interval_seconds
+    )
+    start_http_server(exporter_port)
+    app_metrics.run_metrics_loop()
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/prometheus/prometheus.yaml
+++ b/docker/prometheus/prometheus.yaml
@@ -41,3 +41,7 @@ scrape_configs:
       regex: (.+)
       target_label: __metrics_path__
       replacement: /api/v1/nodes/${1}/proxy/metrics
+  - job_name: 'farcaster gRPC exporter'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['GRPC_EXPORTER_TARGET_PLACEHOLDER']

--- a/docker/prometheus/run.sh
+++ b/docker/prometheus/run.sh
@@ -3,12 +3,14 @@ set -u
 set -e
 
 : "$GRAFANA_API_KEY"
+: "$GRPC_EXPORTER_TARGET"
 
 CONFIG_FILE=/prometheus.yaml
 
 echo $GRAFANA_API_KEY
 
 sed -i s/GRAFANA_API_KEY_PLACEHOLDER/$GRAFANA_API_KEY/g $CONFIG_FILE
+sed -i s/GRPC_EXPORTER_TARGET_PLACEHOLDER/$GRPC_EXPORTER_TARGET/g $CONFIG_FILE
 
 /bin/prometheus \
     --config.file=$CONFIG_FILE \

--- a/terraform/gke_docker_image.tf
+++ b/terraform/gke_docker_image.tf
@@ -1,6 +1,8 @@
 locals {
   image_tag            = "sha256:449368163b6fc653d3a45447d55318e694e7ba74cb86d989d154d7ee0022fd63"
   image                = "${var.region}-docker.pkg.dev/${var.project-id}/${google_artifact_registry_repository.artifact-registry.repository_id}/farcaster-hubble@${local.image_tag}"
-  prometheus-image_tag = "sha256:99864de019d3cd63c01b4f0b1676e1d93dee5a0c0425298aeec59e9937014210"
+  prometheus-image_tag = "sha256:bffd8d08241fea683d3f0270fd6d4c9dd3d822e5c0042c58e6a2936c2393d300"
   prometheus-image     = "${var.region}-docker.pkg.dev/${var.project-id}/${google_artifact_registry_repository.artifact-registry.repository_id}/prometheus@${local.prometheus-image_tag}"
+  grpc-exporter-image_tag = "sha256:d72f1edf53c4d0d59b4d5bb22513f2b6e395053ddeae5081a74b53fc6c6ff407"
+  grpc-exporter-image     = "${var.region}-docker.pkg.dev/${var.project-id}/${google_artifact_registry_repository.artifact-registry.repository_id}/grpc-exporter@${local.grpc-exporter-image_tag}"
 }

--- a/terraform/gke_docker_image.tf
+++ b/terraform/gke_docker_image.tf
@@ -3,6 +3,6 @@ locals {
   image                = "${var.region}-docker.pkg.dev/${var.project-id}/${google_artifact_registry_repository.artifact-registry.repository_id}/farcaster-hubble@${local.image_tag}"
   prometheus-image_tag = "sha256:bffd8d08241fea683d3f0270fd6d4c9dd3d822e5c0042c58e6a2936c2393d300"
   prometheus-image     = "${var.region}-docker.pkg.dev/${var.project-id}/${google_artifact_registry_repository.artifact-registry.repository_id}/prometheus@${local.prometheus-image_tag}"
-  grpc-exporter-image_tag = "sha256:d72f1edf53c4d0d59b4d5bb22513f2b6e395053ddeae5081a74b53fc6c6ff407"
+  grpc-exporter-image_tag = "sha256:5289fa51f3b324f23adfc1fb675d6da20bc330f3d793d4b5b70f3e7b18aff4ba"
   grpc-exporter-image     = "${var.region}-docker.pkg.dev/${var.project-id}/${google_artifact_registry_repository.artifact-registry.repository_id}/grpc-exporter@${local.grpc-exporter-image_tag}"
 }

--- a/terraform/grpc-exporter.tf
+++ b/terraform/grpc-exporter.tf
@@ -1,0 +1,60 @@
+locals {
+  grpc-exporter-app-name   = "grpc-exporter"
+}
+
+resource "kubernetes_deployment" "grpc-exporter" {
+  metadata {
+    name = local.grpc-exporter-app-name
+  }
+  spec {
+    replicas = 1
+    selector {
+      match_labels = {
+        "app" = local.grpc-exporter-app-name
+      }
+    }
+    strategy {
+      type = "Recreate"
+    }
+    template {
+      metadata {
+        labels = {
+          app = local.grpc-exporter-app-name
+        }
+      }
+      spec {
+        container {
+          image = local.grpc-exporter-image
+          name  = "${local.grpc-exporter-app-name}-image"
+          env {
+            name  = "FC_HOSTNAME"
+            value = kubernetes_service.farcaster.metadata[0].name
+          }
+          port {
+            name           = "prom-stats"
+            protocol       = "TCP"
+            container_port = 9090
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "grpc-exporter" {
+  metadata {
+    name = local.grpc-exporter-app-name
+  }
+  spec {
+    type = "ClusterIP"
+    selector = {
+      app = local.grpc-exporter-app-name
+    }
+    port {
+      name        = "prom-stats"
+      protocol    = "TCP"
+      port        = 9090
+      target_port = 9090
+    }
+  }
+}

--- a/terraform/prometheus.tf
+++ b/terraform/prometheus.tf
@@ -78,6 +78,10 @@ resource "kubernetes_deployment" "prometheus" {
               }
             }
           }
+          env {
+            name  = "GRPC_EXPORTER_TARGET"
+            value = "${kubernetes_service.grpc-exporter.metadata[0].name}:9090"
+          }
         }
       }
     }


### PR DESCRIPTION
- Deploys a GRPC exporter to collect metrics from [GetSyncStatus](https://github.com/farcasterxyz/hub-monorepo/blob/main/protobufs/schemas/rpc.proto#L74) and ship them to Grafana via Prometheus

- [Dashboard](https://standardcrypto.grafana.net/d/c29c43d3-c92a-4378-a576-1fd283f1b604/farcaster?orgId=1)

![Screenshot 2023-08-22 at 4 18 08 PM](https://github.com/standard-crypto/farcaster-hub-gcp/assets/93568025/6f3a0fca-5928-407f-971c-df6526a52786)
