### PR TITLE
Disk mount fix

### DIFF
--- a/terraform/gke_deployment.tf
+++ b/terraform/gke_deployment.tf
@@ -28,9 +28,8 @@ resource "kubernetes_deployment" "farcaster" {
           run_as_user = "1000"
         }
         container {
-          image   = local.image
-          name    = "${var.name}-image"
-          command = ["sleep", "50000"]
+          image = local.image
+          name  = "${var.name}-image"
           volume_mount {
             name       = var.name
             mount_path = "/home/node/app/hubble/apps/hubble/.rocks"

--- a/terraform/gke_deployment.tf
+++ b/terraform/gke_deployment.tf
@@ -28,7 +28,7 @@ resource "kubernetes_deployment" "farcaster" {
           name  = "${var.name}-image"
           volume_mount {
             name       = var.name
-            mount_path = "/hubble/apps/hubble/.rocks"
+            mount_path = "/home/node/app/hubble/apps/hubble/.rocks"
           }
           port {
             name           = "hubble-gossip"

--- a/terraform/gke_deployment.tf
+++ b/terraform/gke_deployment.tf
@@ -23,9 +23,13 @@ resource "kubernetes_deployment" "farcaster" {
         }
       }
       spec {
+        security_context {
+          fs_group = "1000" # user 'node'
+        }
         container {
-          image = local.image
-          name  = "${var.name}-image"
+          image   = local.image
+          name    = "${var.name}-image"
+          command = ["sleep", "50000"]
           volume_mount {
             name       = var.name
             mount_path = "/home/node/app/hubble/apps/hubble/.rocks"

--- a/terraform/gke_disk.tf
+++ b/terraform/gke_disk.tf
@@ -54,6 +54,7 @@ resource "kubernetes_persistent_volume" "farcaster" {
     persistent_volume_source {
       gce_persistent_disk {
         pd_name = google_compute_disk.farcaster.name
+        fs_type = "ext4"
       }
     }
   }


### PR DESCRIPTION
An awful nuance of the kubernetes volume driver.

https://kubernetes-csi.github.io/docs/support-fsgroup.html#supported-modes

>ReadWriteOnceWithFSType: Indicates that volumes will be examined to determine if volume ownership and permissions should be modified to match the pod's security policy. Changes will only occur if the fsType is defined and the persistent volume's accessModes contains ReadWriteOnce. .

We had to explicitly set the `fsType` parameter on the volume for the `fsGroup` setting to take effect, instead of just letting `fsType` default to `ext4`