### PR TITLE
hubble v1.5.1

### DIFF
--- a/docker/farcaster-hubble/Dockerfile
+++ b/docker/farcaster-hubble/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20.2-alpine
 
 # https://github.com/farcasterxyz/hubble/tags
-ARG HUBBLE_VERSION="@farcaster/hubble@1.5.0"
+ARG HUBBLE_VERSION="@farcaster/hubble@1.5.1"
 
 # Install required dependencies
 RUN apk add --no-cache libc6-compat python3 make g++ linux-headers curl git

--- a/terraform/gke_docker_image.tf
+++ b/terraform/gke_docker_image.tf
@@ -1,8 +1,8 @@
 locals {
-  image_tag            = "sha256:57f08a7bdd73e754ae67c3b1ec189f94565acb1c89d454948983cb058ffd9cf8"
-  image                = "${var.region}-docker.pkg.dev/${var.project-id}/${google_artifact_registry_repository.artifact-registry.repository_id}/farcaster-hubble@${local.image_tag}"
-  prometheus-image_tag = "sha256:bffd8d08241fea683d3f0270fd6d4c9dd3d822e5c0042c58e6a2936c2393d300"
-  prometheus-image     = "${var.region}-docker.pkg.dev/${var.project-id}/${google_artifact_registry_repository.artifact-registry.repository_id}/prometheus@${local.prometheus-image_tag}"
+  image_tag               = "sha256:740a7abfb09031678d0f7353aadf99c71d5d12eaab071c65621f6bbfe9816fb2"
+  image                   = "${var.region}-docker.pkg.dev/${var.project-id}/${google_artifact_registry_repository.artifact-registry.repository_id}/farcaster-hubble@${local.image_tag}"
+  prometheus-image_tag    = "sha256:bffd8d08241fea683d3f0270fd6d4c9dd3d822e5c0042c58e6a2936c2393d300"
+  prometheus-image        = "${var.region}-docker.pkg.dev/${var.project-id}/${google_artifact_registry_repository.artifact-registry.repository_id}/prometheus@${local.prometheus-image_tag}"
   grpc-exporter-image_tag = "sha256:5289fa51f3b324f23adfc1fb675d6da20bc330f3d793d4b5b70f3e7b18aff4ba"
   grpc-exporter-image     = "${var.region}-docker.pkg.dev/${var.project-id}/${google_artifact_registry_repository.artifact-registry.repository_id}/grpc-exporter@${local.grpc-exporter-image_tag}"
 }


### PR DESCRIPTION
https://github.com/farcasterxyz/hub-monorepo/releases/tag/%40farcaster%2Fhubble%401.5.1

```
9138ca9: chore: Improve dashboard with sync %, versions
8ea938a: fix: Handle both 'docker-compose' and 'docker compose' in hubble.sh
05e5ed1: fix: Stream buffer size to 5K and correct store size limits
```