### PR TITLE
add graphite k8s service

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -100,3 +100,25 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:f143a9a5af42b38fed328a161279906759ff39ac428ebcfe55606e05e1518b93",
   ]
 }
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "5.36.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:+hZ4h8O3QfQFk/fmWftQJVnpNP3xqoCzgf2QlhqTyeg=",
+    "zh:16a8018d4bf8febca9a5482ce66559646f760184e89bb39ed34592451681a252",
+    "zh:1c2781f9938df9ef571d90281c4319fbc1d961afdce6aec4a8faac12da16871a",
+    "zh:48b2155411f1e6dd996ab4abf3846decf6d1404d86ceeb5652e4a982195de4b9",
+    "zh:4f21a97e4d9e5569373ba59a7cf564ab6db9cdea1930f760179ac349f2d03030",
+    "zh:57d39fb320b3f3ffc55d80ae8dd205a2cfc7d9fafb270a371500370f526e0baa",
+    "zh:89b444491a25d789288a80a32531991a29565b6873af5f37face588d04fcff35",
+    "zh:8db5d4bdc47bb0fd71971954bb0c22dcd25c9550b1598f5075fd0a92c040d7ac",
+    "zh:95913de9a0c348bdc0cc1fa727fa8f4c092a311a56981ab7c48959a82a363a70",
+    "zh:9e9aeac23cec279cc0eea6e21eeb8977e291ed9cf831a8d09a147eeda4ef22d8",
+    "zh:bc7a19a4cacb20e26a4021942acefa7b1a05de22250651ef5e3fb36272a5e85b",
+    "zh:c68d27aedec0e6f6551e4db79cc86b6098c626594272265bb3d84bb0bdf99b47",
+    "zh:ca37ae109cf7537b1cb188244ee028df3da34db803a10e9d64d44da9d88b02e7",
+    "zh:db1ac55a2b2d15678845f5a3cde8fae75ef6b67d1830e37488a9e65fbd2caf09",
+    "zh:f14b1b46320455edaed88b74c7324ecea43b5daf382c4cd891fd88addb8b8940",
+  ]
+}

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/grafana/grafana" {
+  version     = "1.40.1"
+  constraints = "1.40.1"
+  hashes = [
+    "h1:qP3uuIFmjHd4d5zlNGpW4DU89k5coSoojdsuunlqETY=",
+    "zh:059a3ad4a05ace3f637628555aa3c3c0d0f82226b854b7ca1d18c04d42b71dfb",
+    "zh:3c941e12c206454c4ce89b3c4bf03e2c18dfe2b6d6498b6321f31e5478e3dd0a",
+    "zh:44f7660a37d712a514910c920b0fa94e111d569f5fee01ed9a20e24ac053e15f",
+    "zh:4c6209de69e9564003eaf334764a8e2693561f8edeb1e26bb3544f9d41b6eb02",
+    "zh:54799b9bcfaed8bc6e0b240b32d5d645decdaec6d6cd2b14b43d159652346fac",
+    "zh:5f6127c7c8326f3ea3ada55bace2f295e30247dccbda9ca2692ad5c3f58bff13",
+    "zh:69d96140ef1b3ca9e8585863d68ba41922e3fa21f0c65f1a3684346955d951e9",
+    "zh:76fc7184de677cbfb455e38c9a8cb29f51ba346b33451b30c71d4493d4e28db0",
+    "zh:83458595fe06b4310c1462f965d8d8e50f756730be9890982f973f4bb61c29fc",
+    "zh:834843f9483f6ad328bff59795a6d70b974404c519f29880bade7072bf0ffa1c",
+    "zh:e52cce3c15de816dcc4fb05f08d63427e8bc5e074dc6976c5066be97cb92614a",
+    "zh:eb65cbe8b9c21e024fa1882b07806088d3506e0d4c13c0c33496721533b002ea",
+    "zh:f54bdc1bc08238f116d50b6ff17c3b1514966e52b1e0fd3ddb6230da022b606e",
+    "zh:f68688692cc589368c5d3e1d2512c59b292f3d06ec3a595c56bdaf04e2ecfebe",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/google" {
   version     = "4.58.0"
   constraints = "~> 4.0"

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.0"
     }
+    grafana = {
+      source  = "grafana/grafana"
+      version = "1.40.1"
+    }
   }
 
   backend "remote" {

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "grafana/grafana"
       version = "1.40.1"
     }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.0"
+    }
   }
 
   backend "remote" {

--- a/terraform/gke_deployment.tf
+++ b/terraform/gke_deployment.tf
@@ -93,26 +93,17 @@ resource "kubernetes_deployment" "farcaster" {
           }
           command = ["yarn", "start"]
           args = [
-            "--eth-mainnet-rpc-url",
-            "$(ETH_MAINNET_RPC_URL)",
-            "--l2-rpc-url",
-            "$(OPTIMISM_L2_RPC_URL)",
-            "--announce-server-name",
-            "$(HUB_HOSTNAME)",
-            "--announce-ip",
-            "$(HUB_IP)",
-            "--network",
-            "$(HUB_NETWORK)",
-            "--gossip-port",
-            "2282",
-            "--rpc-port",
-            "2283",
-            "--ip",
-            "0.0.0.0",
-            "--db-name",
-            "farcaster",
-            "--hub-operator-fid",
-            var.hubble-operator-fid
+            "--eth-mainnet-rpc-url", "$(ETH_MAINNET_RPC_URL)",
+            "--l2-rpc-url", "$(OPTIMISM_L2_RPC_URL)",
+            "--announce-server-name", "$(HUB_HOSTNAME)",
+            "--announce-ip", "$(HUB_IP)",
+            "--network", "$(HUB_NETWORK)",
+            "--gossip-port", "2282",
+            "--rpc-port", "2283",
+            "--ip", "0.0.0.0",
+            "--db-name", "farcaster",
+            "--hub-operator-fid", var.hubble-operator-fid,
+            "--statsd-metrics-server", module.graphite.statsd_host
           ]
         }
         volume {

--- a/terraform/gke_secrets.tf
+++ b/terraform/gke_secrets.tf
@@ -49,3 +49,9 @@ resource "kubernetes_secret" "grafana-api-key" {
     ignore_changes = all
   }
 }
+
+data "kubernetes_secret" "grafana-api-key" {
+  metadata {
+    name = kubernetes_secret.grafana-api-key.metadata[0].name
+  }
+}

--- a/terraform/grafana_cloud.tf
+++ b/terraform/grafana_cloud.tf
@@ -1,4 +1,5 @@
 module "grafana_cloud" {
   source                   = "./modules/grafana_cloud"
   grafana_cloud_stack_name = var.grafana_cloud_stack_name
+  graphite_url             = module.graphite.graphite_web_url
 }

--- a/terraform/grafana_cloud.tf
+++ b/terraform/grafana_cloud.tf
@@ -1,4 +1,4 @@
 module "grafana_cloud" {
   source                   = "./modules/grafana_cloud"
-  grafana_cloud_stack_name = "scfarcasterhub"
+  grafana_cloud_stack_name = var.grafana_cloud_stack_name
 }

--- a/terraform/grafana_cloud.tf
+++ b/terraform/grafana_cloud.tf
@@ -1,0 +1,4 @@
+module "grafana_cloud" {
+  source                   = "./modules/grafana_cloud"
+  grafana_cloud_stack_name = "scfarcasterhub"
+}

--- a/terraform/grafana_cloud.tf
+++ b/terraform/grafana_cloud.tf
@@ -2,4 +2,7 @@ module "grafana_cloud" {
   source                   = "./modules/grafana_cloud"
   grafana_cloud_stack_name = var.grafana_cloud_stack_name
   graphite_url             = module.graphite.graphite_web_url
+  providers = {
+    grafana.cloud = grafana.cloud
+  }
 }

--- a/terraform/graphite.tf
+++ b/terraform/graphite.tf
@@ -1,0 +1,6 @@
+module "graphite" {
+  source        = "./modules/graphite"
+  project_id    = var.project-id
+  region        = var.region
+  dns_zone_name = google_dns_managed_zone.dns-zone.name
+}

--- a/terraform/modules/grafana_cloud/dashboard.tf
+++ b/terraform/modules/grafana_cloud/dashboard.tf
@@ -1,0 +1,12 @@
+
+data "github_repository_file" "grafana_dashboard_json" {
+  repository = "farcasterxyz/hub-monorepo"
+  branch     = "main"
+  file       = "apps/hubble/grafana/grafana-dashboard.json"
+}
+
+resource "grafana_dashboard" "default_hubble_dashboard" {
+  provider = grafana.farcaster_stack
+
+  config_json = data.github_repository_file.grafana_dashboard_json.content
+}

--- a/terraform/modules/grafana_cloud/graphite.tf
+++ b/terraform/modules/grafana_cloud/graphite.tf
@@ -1,0 +1,6 @@
+resource "grafana_data_source" "graphite" {
+  provider = grafana.farcaster_stack
+  type     = "graphite"
+  name     = "Graphite"
+  url      = var.graphite_url
+}

--- a/terraform/modules/grafana_cloud/input_vars.tf
+++ b/terraform/modules/grafana_cloud/input_vars.tf
@@ -2,3 +2,8 @@ variable "grafana_cloud_stack_name" {
   type        = string
   description = "Name of the stack (One word. Only lowercase letters and numbers allowed. Must start with a letter. No dots, dashes, underscores, or spaces.)"
 }
+
+variable "graphite_url" {
+  type        = string
+  description = "URL of the hub's graphite instance"
+}

--- a/terraform/modules/grafana_cloud/input_vars.tf
+++ b/terraform/modules/grafana_cloud/input_vars.tf
@@ -1,0 +1,4 @@
+variable "grafana_cloud_stack_name" {
+  type        = string
+  description = "Name of the stack (One word. Only lowercase letters and numbers allowed. Must start with a letter. No dots, dashes, underscores, or spaces.)"
+}

--- a/terraform/modules/grafana_cloud/providers.tf
+++ b/terraform/modules/grafana_cloud/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "1.40.1"
+    }
+  }
+}
+
+

--- a/terraform/modules/grafana_cloud/providers.tf
+++ b/terraform/modules/grafana_cloud/providers.tf
@@ -4,7 +4,17 @@ terraform {
       source  = "grafana/grafana"
       version = "1.40.1"
     }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.0"
+    }
   }
 }
 
 
+provider "grafana" {
+  alias = "farcaster_stack"
+
+  url  = grafana_cloud_stack.farcaster_stack.url
+  auth = grafana_cloud_stack_service_account_token.cloud_sa.key
+}

--- a/terraform/modules/grafana_cloud/providers.tf
+++ b/terraform/modules/grafana_cloud/providers.tf
@@ -1,16 +1,14 @@
 terraform {
   required_providers {
     grafana = {
-      source  = "grafana/grafana"
-      version = "1.40.1"
+      source                = "grafana/grafana"
+      configuration_aliases = [grafana.cloud]
     }
     github = {
-      source  = "integrations/github"
-      version = "~> 5.0"
+      source = "integrations/github"
     }
   }
 }
-
 
 provider "grafana" {
   alias = "farcaster_stack"

--- a/terraform/modules/grafana_cloud/stack.tf
+++ b/terraform/modules/grafana_cloud/stack.tf
@@ -1,0 +1,6 @@
+resource "grafana_cloud_stack" "farcaster_stack" {
+  name        = var.grafana_cloud_stack_name
+  slug        = var.grafana_cloud_stack_name
+  description = "Farcaster Hub Metrics"
+  region_slug = "us"
+}

--- a/terraform/modules/grafana_cloud/stack.tf
+++ b/terraform/modules/grafana_cloud/stack.tf
@@ -1,6 +1,28 @@
+provider "grafana" {
+  alias = "cloud"
+}
+
 resource "grafana_cloud_stack" "farcaster_stack" {
+  provider    = grafana.cloud
   name        = var.grafana_cloud_stack_name
   slug        = var.grafana_cloud_stack_name
   description = "Farcaster Hub Metrics"
   region_slug = "us"
+}
+
+resource "grafana_cloud_stack_service_account" "cloud_sa" {
+  provider   = grafana.cloud
+  stack_slug = grafana_cloud_stack.farcaster_stack.slug
+
+  name        = "Terraform service account"
+  role        = "Admin"
+  is_disabled = false
+}
+
+resource "grafana_cloud_stack_service_account_token" "cloud_sa" {
+  provider   = grafana.cloud
+  stack_slug = grafana_cloud_stack.farcaster_stack.slug
+
+  name               = "Terraform service account key"
+  service_account_id = grafana_cloud_stack_service_account.cloud_sa.id
 }

--- a/terraform/modules/grafana_cloud/stack.tf
+++ b/terraform/modules/grafana_cloud/stack.tf
@@ -1,7 +1,3 @@
-provider "grafana" {
-  alias = "cloud"
-}
-
 resource "grafana_cloud_stack" "farcaster_stack" {
   provider    = grafana.cloud
   name        = var.grafana_cloud_stack_name

--- a/terraform/modules/graphite/dns.tf
+++ b/terraform/modules/graphite/dns.tf
@@ -1,0 +1,12 @@
+data "google_dns_managed_zone" "dns_zone" {
+  name = var.dns_zone_name
+}
+
+resource "google_dns_record_set" "graphite_dns_recordset" {
+  provider     = google-beta
+  managed_zone = data.google_dns_managed_zone.dns_zone.name
+  name         = "graphite.${data.google_dns_managed_zone.dns_zone.dns_name}"
+  type         = "A"
+  rrdatas      = [google_compute_address.graphite_ip.address]
+  ttl          = 86400
+}

--- a/terraform/modules/graphite/gke_deployment.tf
+++ b/terraform/modules/graphite/gke_deployment.tf
@@ -1,0 +1,71 @@
+locals {
+  app_name          = "graphite"
+  statsd_port       = 8125
+  graphite_web_port = 80
+}
+
+resource "kubernetes_deployment" "graphite" {
+  metadata {
+    name = "graphite"
+  }
+  spec {
+    replicas = 1
+    selector {
+      match_labels = {
+        "app" = local.app_name
+      }
+    }
+    strategy {
+      type = "Recreate"
+    }
+    template {
+      metadata {
+        labels = {
+          app = local.app_name
+        }
+      }
+      spec {
+        container {
+          image = "graphiteapp/graphite-statsd:1.1.10-5"
+          name  = "${local.app_name}-image"
+          port {
+            name           = "statsd"
+            protocol       = "UDP"
+            container_port = local.statsd_port
+          }
+          port {
+            name           = "graphite-web"
+            protocol       = "TCP"
+            container_port = local.graphite_web_port
+          }
+        }
+      }
+    }
+  }
+  timeouts {
+    create = "5m"
+    update = "5m"
+  }
+}
+
+resource "kubernetes_service" "graphite" {
+  metadata {
+    name = local.app_name
+    annotations = {
+      "cloud.google.com/network-tier" = "Standard"
+    }
+  }
+  spec {
+    type = "LoadBalancer"
+    selector = {
+      app = local.app_name
+    }
+    port {
+      name        = "graphite-web"
+      protocol    = "TCP"
+      port        = local.graphite_web_port
+      target_port = local.graphite_web_port
+    }
+    load_balancer_ip = google_compute_address.graphite_ip.address
+  }
+}

--- a/terraform/modules/graphite/gke_deployment.tf
+++ b/terraform/modules/graphite/gke_deployment.tf
@@ -6,7 +6,7 @@ locals {
 
 resource "kubernetes_deployment" "graphite" {
   metadata {
-    name = "graphite"
+    name = local.app_name
   }
   spec {
     replicas = 1
@@ -65,6 +65,12 @@ resource "kubernetes_service" "graphite" {
       protocol    = "TCP"
       port        = local.graphite_web_port
       target_port = local.graphite_web_port
+    }
+    port {
+      name        = "statsd"
+      protocol    = "UDP"
+      port        = local.statsd_port
+      target_port = local.statsd_port
     }
     load_balancer_ip = google_compute_address.graphite_ip.address
   }

--- a/terraform/modules/graphite/input_vars.tf
+++ b/terraform/modules/graphite/input_vars.tf
@@ -1,0 +1,14 @@
+variable "project_id" {
+  type        = string
+  description = "GCP Project ID"
+}
+
+variable "region" {
+  type        = string
+  description = "GCP Region"
+}
+
+variable "dns_zone_name" {
+  type        = string
+  description = "Name of the Google Cloud DNS managed zone"
+}

--- a/terraform/modules/graphite/ip.tf
+++ b/terraform/modules/graphite/ip.tf
@@ -1,0 +1,5 @@
+resource "google_compute_address" "graphite_ip" {
+  name         = "graphite-ip"
+  region       = var.region
+  network_tier = "STANDARD"
+}

--- a/terraform/modules/graphite/outputs.tf
+++ b/terraform/modules/graphite/outputs.tf
@@ -1,3 +1,7 @@
 output "statsd_host" {
   value = "${kubernetes_service.graphite.metadata[0].name}:${local.statsd_port}"
 }
+
+output "graphite_web_url" {
+  value = "http://${trimsuffix(google_dns_record_set.graphite_dns_recordset.name, ".")}"
+}

--- a/terraform/modules/graphite/outputs.tf
+++ b/terraform/modules/graphite/outputs.tf
@@ -1,0 +1,3 @@
+output "statsd_host" {
+  value = "${kubernetes_service.graphite.metadata[0].name}:${local.statsd_port}"
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -15,3 +15,7 @@ provider "kubernetes" {
   token                  = data.google_client_config.default.access_token
   cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }
+
+provider "grafana" {
+  alias = "cloud"
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -19,3 +19,5 @@ provider "kubernetes" {
 provider "grafana" {
   alias = "cloud"
 }
+
+provider "github" {}

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -36,3 +36,8 @@ variable "hubble-operator-fid" {
   type    = string
   default = "69" # gavi
 }
+
+variable "grafana_cloud_stack_name" {
+  type    = string
+  default = "scfarcasterhub"
+}

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -41,3 +41,8 @@ variable "grafana_cloud_stack_name" {
   type    = string
   default = "scfarcasterhub"
 }
+
+variable "grafana_cloud_org" {
+  type    = string
+  default = "standardcrypto"
+}


### PR DESCRIPTION
- Creates a separate Grafana Cloud "stack" for farcaster hub metrics (creating new stacks is free, we just get billed for data used across all stacks)
- Deploys graphite and statsd to the kubernetes cluster with public IP and DNS name
- Adds a data connection to Grafana Cloud to read from the local graphite instance
- Deploys the default grafana dashboard that the farcaster team provides in the hubble repo

Note: I didn't setup a persistent volume for the graphite instance in kubernetes. That means the stats history will reset when the instance is recreated, but I'm not sure that we care too much about historical data here.

Tried out using terraform submodules to separate out the code for these things from our existing infra code.

Grafana dashboard is here: https://scfarcasterhub.grafana.net/d/af04c037-bd8f-484a-b93e-0cb4b7d3b026/hubble-dashboard