### PR TITLE
Automate releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,7 @@ jobs:
         if [[ $latest_release == "@farcaster/hubble"* ]]; then
           # Strip away the version to get only "X.Y.Z" and set it in the output variable
           version=$(echo $latest_release | sed 's/@farcaster\/hubble//')
-          version=$(echo $version | tr -d '[:punct:]' | tr -d '[:space:]')
-          echo "Stripped version: $version"
+          echo "version: $version"
           echo "::set-output name=latest_version::$version"
         else
           echo "Invalid release format: $latest_release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     #   uses: actions/checkout@v2
 
     - name: Fetch latest release
-      id: latest_release
+      id: latest_version
       run: |
         latest_release=$(curl -s https://api.github.com/repos/farcasterxyz/hub-monorepo/releases/latest | jq -r '.tag_name')
 
@@ -32,6 +32,18 @@ jobs:
       shell: bash
 
 
-    - name: Print Version
+    - name: Get Current Version
+      id: current_version
       run: |
-        echo "version: ${{ steps.latest_release.outputs.version }}"
+        # Extract the current version from terraform/gke_deployment.tf file
+        current_version=$(grep -oP '(?<=image = "farcasterxyz/hubble:)[^"]*' terraform/gke_deployment.tf)
+        echo "Current version in terraform file: $current_version"
+        echo "version=$current_version" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+
+    - name: Print Versions
+      run: |
+        echo "current version: ${{ steps.current_version.outputs.version }}"
+        echo "latest version: ${{ steps.latest_version.outputs.version }}"
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,12 @@ jobs:
         sed -i "s/image = \"farcasterxyz\/hubble:.*\"/image = \"farcasterxyz\/hubble:${{ steps.latest_version.outputs.version }}\"/" terraform/gke_deployment.tf
         cat terraform/gke_deployment.tf
 
-    - name: Print Versions
+    - name: Commit And Push Changes
+      if: ${{ steps.latest_version.outputs.version != steps.current_version.outputs.version }}
       run: |
-        echo "current version: ${{ steps.current_version.outputs.version }}"
-        echo "latest version: ${{ steps.latest_version.outputs.version }}"
-
+        git status
+        git add terraform/gke_deployment.tf
+        git status
+        git commit -m "Update Hubble version to ${{ steps.latest_version.outputs.version }}"
+        git status
+        git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Daily Trigger
+
+on:
+  schedule:
+    - cron: '0 18 * * *' # Triggers at 6pm UTC (10 AM PST) every day
+  workflow_dispatch: # Manual trigger
+
+jobs:
+  trigger-job:
+    runs-on: ubuntu-latest
+
+    steps:
+    # - name: Checkout repository
+    #   uses: actions/checkout@v2
+
+    - name: Fetch latest release
+      id: latest_release
+      run: |
+        latest_release=$(curl -s https://api.github.com/repos/farcasterxyz/hub-monorepo/releases/latest | jq -r '.tag_name')
+
+        # Verify that the release starts with "@farcaster/hubble"
+        if [[ $latest_release == "@farcaster/hubble"* ]]; then
+          # Strip away the version to get only "X.Y.Z" and set it in the output variable
+          version=$(echo $latest_release | sed 's/@farcaster\/hubble//')
+          version=$(echo $version | tr -d '[:punct:]' | tr -d '[:space:]')
+          echo "Stripped version: $version"
+          echo "::set-output name=latest_version::$version"
+        else
+          echo "Invalid release format: $latest_release"
+          exit 1
+        fi
+      shell: bash
+
+
+    - name: Print Version
+      run: |
+        echo "Latest version: ${{ steps.latest_release.outputs.latest_version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
         latest_release=$(curl -s https://api.github.com/repos/farcasterxyz/hub-monorepo/releases/latest | jq -r '.tag_name')
 
         # Verify that the release starts with "@farcaster/hubble"
-        if [[ $latest_release == "@farcaster/hubble"* ]]; then
+        if [[ $latest_release == "@farcaster/hubble@"* ]]; then
           # Strip away the version to get only "X.Y.Z" and set it in the output variable
-          version=$(echo $latest_release | sed 's/@farcaster\/hubble//')
+          version=$(echo $latest_release | sed 's/@farcaster\/hubble@//')
           echo "version: $version"
           echo "::set-output name=latest_version::$version"
         else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,8 @@ jobs:
     - name: Commit And Push Changes
       if: ${{ steps.latest_version.outputs.version != steps.current_version.outputs.version }}
       run: |
-        git status
+        git config --global user.email "93568025+piratekev@users.noreply.github.com"
+        git config --global user.name "Kevin Ayling"
         git add terraform/gke_deployment.tf
-        git status
         git commit -m "Update Hubble version to ${{ steps.latest_version.outputs.version }}"
-        git status
         git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Fetch latest release
       id: latest_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: # Manual trigger
 
 jobs:
-  trigger-job:
+  check-and-update-release:
     runs-on: ubuntu-latest
 
     steps:
@@ -41,6 +41,13 @@ jobs:
         echo "version=$current_version" >> "$GITHUB_OUTPUT"
       shell: bash
 
+
+    - name: Update Version in Terraform Config
+      if: ${{ steps.latest_version.outputs.version != steps.current_version.outputs.version }}
+      run: |
+        # Update the version in terraform/gke_deployment.tf file
+        sed -i "s/image = \"farcasterxyz\/hubble:.*\"/image = \"farcasterxyz\/hubble:$version\"/" terraform/gke_deployment.tf
+        cat terraform/gke_deployment.tf
 
     - name: Print Versions
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       if: ${{ steps.latest_version.outputs.version != steps.current_version.outputs.version }}
       run: |
         # Update the version in terraform/gke_deployment.tf file
-        sed -i "s/image = \"farcasterxyz\/hubble:.*\"/image = \"farcasterxyz\/hubble:$version\"/" terraform/gke_deployment.tf
+        sed -i "s/image = \"farcasterxyz\/hubble:.*\"/image = \"farcasterxyz\/hubble:${{ steps.latest_version.outputs.version }}\"/" terraform/gke_deployment.tf
         cat terraform/gke_deployment.tf
 
     - name: Print Versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # - name: Checkout repository
-    #   uses: actions/checkout@v2
+    - name: Checkout repository
+      uses: actions/checkout@v2
 
     - name: Fetch latest release
       id: latest_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Daily Trigger
+name: Fetch Latest Release
 
 on:
   schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,8 @@ jobs:
           # Strip away the version to get only "X.Y.Z" and set it in the output variable
           version=$(echo $latest_release | sed 's/@farcaster\/hubble@//')
           echo "version: $version"
-          echo "::set-output name=latest_version::$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
         else
           echo "Invalid release format: $latest_release"
           exit 1
@@ -33,4 +34,4 @@ jobs:
 
     - name: Print Version
       run: |
-        echo "Latest version: ${{ steps.latest_release.outputs.latest_version }}"
+        echo "version: ${{ steps.latest_release.outputs.version }}"

--- a/terraform/gke_deployment.tf
+++ b/terraform/gke_deployment.tf
@@ -28,7 +28,7 @@ resource "kubernetes_deployment" "farcaster" {
           run_as_user = "1000"
         }
         container {
-          image = "farcasterxyz/hubble:1.7.0"
+          image = "farcasterxyz/hubble:1.8.0"
           name  = "${var.name}-image"
           volume_mount {
             name       = var.name

--- a/terraform/gke_deployment.tf
+++ b/terraform/gke_deployment.tf
@@ -28,7 +28,7 @@ resource "kubernetes_deployment" "farcaster" {
           run_as_user = "1000"
         }
         container {
-          image = "farcasterxyz/hubble:1.8.0"
+          image = "farcasterxyz/hubble:1.7.0"
           name  = "${var.name}-image"
           volume_mount {
             name       = var.name


### PR DESCRIPTION
This PR updates the existing workflow to update and push the updated version. The flow is:

1. Get latest version from https://github.com/farcasterxyz/hub-monorepo/releases
2. Get current version from terraform/gke_deployment.tf
if current and latest versions differ:
3. Update version in terraform/gke_deployment.tf
4. Commit and push change

See a test run of it here: https://github.com/standard-crypto/farcaster-hub-gcp/actions/runs/7053379179/job/19200315691