### PR TITLE
vertical autoscaling max

### DIFF
--- a/terraform/gke_deployment.tf
+++ b/terraform/gke_deployment.tf
@@ -188,6 +188,14 @@ resource "kubernetes_manifest" "farcaster-vertical-autoscaler" {
         updateMode  = "Auto"
         minReplicas = 1
       }
+      resourcePolicy = {
+        containerPolicies = [{
+          containerName = "${var.name}-container"
+          maxAllowed = {
+            memory = "12Gi"
+          }
+        }]
+      }
     }
   }
 }


### PR DESCRIPTION
K8s tried to autoscale the memory requests of our container up to 17Gi, which is more than any node in the cluster could support.

This puts an upper limit on the memory autoscaling

![Screenshot 2024-03-25 at 11 32 33 AM](https://github.com/standard-crypto/farcaster-hub-gcp/assets/2490863/34ddffbe-9524-49bf-baf0-2495e7191cef)
